### PR TITLE
config on interactive-form workflow to permit new auth to continue to handler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.cemerick/friend "0.0.3"
+(defproject org.clojars.mccraigmccraig/friend "0.0.4-SNAPSHOT"
   :description "Authentication and authorization library for Ring Clojure web apps and services."
   :url "http://github.com/cemerick/friend"
   :license {:name "Eclipse Public License"
@@ -17,7 +17,7 @@
                  [org.openid4java/openid4java-consumer "0.9.6" :extension "pom"]
                  ; need different httpclient rev for https://issues.apache.org/jira/browse/HTTPCLIENT-1118
                  [org.apache.httpcomponents/httpclient "4.2-beta1"]]
-  
+
   :profiles {:dev {:dependencies [[ring-mock "0.1.1"]
                                   [compojure "1.0.1"]
                                   [ring "1.0.2"]

--- a/src/cemerick/friend/workflows.clj
+++ b/src/cemerick/friend/workflows.clj
@@ -50,7 +50,8 @@
                                       param))))
 
 (defn interactive-form
-  [& {:keys [login-uri credential-fn login-failure-handler] :as form-config}]
+  [& {:keys [login-uri credential-fn login-failure-handler redirect-on-auth?] :as form-config
+      :or {redirect-on-auth? true}}]
   (fn [{:keys [uri request-method params] :as request}]
     (when (and (= login-uri uri)
                (= :post request-method))
@@ -60,7 +61,7 @@
                                     (with-meta creds {::friend/workflow :interactive-form})))]
           (with-meta (username-as-identity user-record)
             {::friend/workflow :interactive-form
-             :type ::friend/auth})
+             :type ::friend/auth
+             ::friend/redirect-on-auth? redirect-on-auth?})
           ((or (gets :login-failure-handler form-config (::friend/auth-config request)) #'interactive-login-redirect)
             (update-in request [::friend/auth-config] merge form-config)))))))
-

--- a/test/test_friend/interactive_form.clj
+++ b/test/test_friend/interactive_form.clj
@@ -15,21 +15,22 @@
                                                                    (= "Aladdin" username))
                                                           {:identity username})))]
     (is (nil? (form-handler (request :get login-uri))))
-    
+
     (is (= {:status 302
             :headers {"Location" "/my_login?&login_failed=Y&username="}
             :body ""}
            (form-handler (request :post login-uri))))
-    
+
     (is (= {:status 302
             :headers {"Location" "/my_login?&login_failed=Y&username=foo"}
             :body ""}
            (form-handler (assoc (request :post login-uri)
                                 :params {:username "foo"}))))
-    
+
     (let [auth (form-handler (assoc (request :post login-uri)
                                     :params {:username "Aladdin"
-                                             :password "open sesame"}))] 
+                                             :password "open sesame"}))]
       (is (= auth {:identity "Aladdin"}))
       (is (= (meta auth) {::friend/workflow :interactive-form
-                          :type ::friend/auth})))))
+                          :type ::friend/auth
+                          ::friend/redirect-on-auth? true})))))


### PR DESCRIPTION
i want my handler to get the request even in the case of new auth : this patch adds configuration to the interactive-form workflow to set the ::friend/redirect-on-auth? metadata to permit this
