### PR TITLE
Adjust core abstraction to allow ::openid-disc to be dissoc'ed

### DIFF
--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -125,7 +125,7 @@ Equivalent to (complement current-authentication)."}
           resp (response/redirect-after-post (or unauthorized-uri (-> request ::auth-config :default-landing-uri)))]
       (if unauthorized-uri
         (-> resp
-          (assoc :session (:session request))
+          (assoc :session (:session authentication-map))
           (update-in [:session] dissoc ::unauthorized-uri))
         resp))))
 

--- a/src/cemerick/friend/openid.clj
+++ b/src/cemerick/friend/openid.clj
@@ -79,8 +79,7 @@
     (let [response (.getAuthResponse verification)]
       (reduce merge (cons {:identity identification} (gather-attr-maps response))))))
 
-;; TODO something off in the core abstraction: cannot clear the ::openid-disc session key
-;;    when authentication succeeds here...
+
 (defn- handle-return
   [^ConsumerManager mgr {:keys [params session] :as req} openid-config]
   (let [provider-info (::openid-disc session)


### PR DESCRIPTION
The return value from the workflow is authentication-map, which has the most current version of :session in it, with ::openid-disc dissoc'ed after successful auth. 

Adjust redirect-new-auth to return the modified :session instead of the unmodified original request :session.
