### PR TITLE
Stash modified :session in metadata of auth-map of workflow,

### DIFF
--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -44,10 +44,13 @@
                                   :server-port (scheme-mapping scheme))))))))
 
 (defn merge-authentication
+  "If the workflow has modified the session and passed it in meta, use it.
+  Then update the authentications."
   [m auth]
-  (update-in m [:session ::identity]
-             #(-> (assoc-in % [:authentications (:identity auth)] auth)
-                (assoc :current (:identity auth)))))
+  (let [new-session (or (-> auth meta :session) (:session m))]
+    (assoc m :session (update-in new-session [::identity]
+                              #(-> (assoc-in % [:authentications (:identity auth)] auth)
+                                   (assoc :current (:identity auth)))))))
 
 (defn- logout*
   [response]


### PR DESCRIPTION
so it can be passed up from the workflow, and then restore it in the merge-authentication function of the core abstraction.

This is a second-- and hopefully more correct-- attempt at allowing the openid workflow to dissoc the ::openid-disc from the workflow when the auth succeeds.

It works, but I can keep banging on it if it is still not quite right.
