### PR TITLE
url-encode username passed to login-uri after failure

### DIFF
--- a/src/cemerick/friend/workflows.clj
+++ b/src/cemerick/friend/workflows.clj
@@ -60,7 +60,7 @@
 (defn interactive-login-redirect
   [{:keys [params] :as request}]
   (ring.util.response/redirect (let [param (str "&login_failed=Y&username=" (java.net.URLEncoder/encode
-                                                                              (:username params)))
+                                                                              (:username params "")))
                                      login-uri (-> request ::friend/auth-config :login-uri)]
                                  (str (if (.contains login-uri "?") login-uri (str login-uri "?"))
                                       param))))


### PR DESCRIPTION
If the username contains + or other special characters, the encoding can get messed up.
