### PR TITLE
Split up authenticate

### DIFF
--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -205,7 +205,7 @@ Equivalent to (complement current-authentication)."}
           :catch-handler (if auth unauthorized-handler unauthenticated-handler)})))))
 
 (defn handler-request
-  "Calls handler with approprite binding and error catching and returns a response."
+  "Calls handler with appropriate binding and error catching and returns a response."
   [handler {:keys [catch-handler request auth]}]
   (binding [*identity* auth]
     (try+


### PR DESCRIPTION
Hey Chas,

It was good to hang out and chat in person. :)

This pull request is for splitting up `authenticate*` into `authenticate-request` and `authenticate-response`. These fns respectively handle request and response wrapping. The naming convention and approach are the same as what [we did for ring](https://github.com/ring-clojure/ring/pull/38). The pedestal friend sample that uses this fork [is here](https://github.com/pedestal/samples/tree/friend-sample/friend-auth).

Some things to point out about this implementation:
- Notice `handler-request` is public since in pedestal we want to wrap the handler with the same error handling.
- :friend/ensure-identity-request saves a new version of request deep within authenticate-request for use in authenticate-response. I chose to namespace it with :friend to guarantee it doesn't clash with anything else. We could also use ::ensure-identity-request.
- I moved config keys to the fns they were being used with in order to make it more explicit where they were needed.

I'd love to get feedback on what you think and how I can improve it.
