### PR TITLE
default-unauthenticated-handler retains query-string on unauthorized-uri

### DIFF
--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -162,7 +162,7 @@ Equivalent to (complement current-authentication)."}
     (util/resolve-absolute-uri request)
     ring.util.response/redirect
     (assoc :session (:session request))
-    (assoc-in [:session ::unauthorized-uri] (:uri request))))
+    (assoc-in [:session ::unauthorized-uri] (util/original-url request))))
 
 (defn authenticate-response
   "Adds to the response's :session for responses with a :friend/ensure-identity-request key."

--- a/test/test_friend/functional.clj
+++ b/test/test_friend/functional.clj
@@ -62,14 +62,14 @@
 
 (deftest user-login
   (binding [clj-http.core/*cookie-store* (clj-http.cookies/cookie-store)]
-    (is (= (page-bodies "/login") (:body (http/get (url "/user/account")))))
+    (is (= (page-bodies "/login") (:body (http/get (url "/user/account?query-string=test")))))
     (let [resp (http/post (url "/login")
                  {:form-params {:username "jane" :password "user_password"}})]
       ; ensure that previously-requested page is redirected to upon redirecting authentication
       ; clj-http *should* redirect us, but isn't yet; working on it: 
       ; https://github.com/dakrone/clj-http/issues/57
       (is (http/redirect? resp))
-      (is (= "/user/account" (-> resp :headers (get "location")))))
+      (is (= (url "/user/account?query-string=test") (-> resp :headers (get "location")))))
     (check-user-role-access)
     (is (= {:roles ["test-friend.mock-app/user"]} (:body (http/get (url "/echo-roles") {:as :json}))))
     


### PR DESCRIPTION
Fixes #68, extends the test to account for query-strings.

I've used util/original-url, to account for #42 too.

Sorry for changes in whitespace, my emacs is set to clean those automatically.
