### PR TITLE
Make use of `:unauthenticated-handler` in the `http-basic` workflow.

### DIFF
--- a/src/cemerick/friend/workflows.clj
+++ b/src/cemerick/friend/workflows.clj
@@ -54,7 +54,8 @@
           (make-auth user-record
                      {::friend/workflow :http-basic
                       ::friend/redirect-on-auth? false})
-          (http-basic-deny realm request))
+          ((or (:unauthenticated-handler (::friend/auth-config request))
+               (partial http-basic-deny realm)) request))
         {:status 400 :body "Malformed Authorization header for HTTP Basic authentication."}))))
 
 (defn interactive-login-redirect


### PR DESCRIPTION
Setting the `:unauthenticated-handler` had no effect previously when using the `http-basic` workflow. If not set, the call to `http-basic-deny` still takes place as it did before.
