### PR TITLE
return auth denied if no auth header present on http-basic workflow.

### DIFF
--- a/src/cemerick/friend/workflows.clj
+++ b/src/cemerick/friend/workflows.clj
@@ -35,7 +35,7 @@
 (defn http-basic
   [& {:keys [credential-fn realm] :as basic-config}]
   (fn [{{:strs [authorization]} :headers :as request}]
-    (when authorization
+    (if authorization
       (if-let [[[_ username password]] (try (-> (re-matches #"\s*Basic\s+(.+)" authorization)
                                               ^String second
                                               (.getBytes "UTF-8")
@@ -55,7 +55,8 @@
                      {::friend/workflow :http-basic
                       ::friend/redirect-on-auth? false})
           (http-basic-deny realm request))
-        {:status 400 :body "Malformed Authorization header for HTTP Basic authentication."}))))
+        {:status 400 :body "Malformed Authorization header for HTTP Basic authentication."})
+      (http-basic-deny realm request))))
 
 (defn- username
   [form-params params]

--- a/test/test_friend/http_basic.clj
+++ b/test/test_friend/http_basic.clj
@@ -40,4 +40,9 @@
     (is (= {:status 401, :headers {"Content-Type" "text/plain"
                                    "WWW-Authenticate" "Basic realm=\"friend-test\""}}
           ((http-basic :realm "friend-test" :credential-fn (constantly nil))
-            (header req "Authorization" auth))))))
+            (header req "Authorization" auth))))
+
+    (is (= {:status 401, :headers {"Content-Type" "text/plain"
+                                   "WWW-Authenticate" "Basic realm=\"friend-test\""}}
+          ((http-basic :realm "friend-test" :credential-fn (constantly nil))
+            req)))))


### PR DESCRIPTION
currently the http-basic auth scheme fails since when the user comes unauthenticated redirects to /login instead of asking for credentials.
