### PR TITLE
retrieve password same way as username

### DIFF
--- a/src/cemerick/friend/workflows.clj
+++ b/src/cemerick/friend/workflows.clj
@@ -61,6 +61,10 @@
   [form-params params]
   (or (get form-params "username") (:username params "")))
 
+(defn- password
+  [form-params params]
+  (or (get form-params "password") (:password params "")))
+
 (defn interactive-login-redirect
   [{:keys [form-params params] :as request}]
   (ring.util.response/redirect
@@ -79,7 +83,7 @@
     (when (and (= (gets :login-uri form-config (::friend/auth-config request)) (req/path-info request))
                (= :post request-method))
       (let [creds {:username (username form-params params)
-                   :password (:password params)}
+                   :password (password form-params params)}
             {:keys [username password]} creds]
         (if-let [user-record (and username password
                                   ((gets :credential-fn form-config (::friend/auth-config request))


### PR DESCRIPTION
Update interactive-form workflow to check form-params for "password" key, as is done for username.

There is certainly a prettier way to handle both of these, but this should suffice.
