### PR TITLE
Update README to mention usage of compojure.handler/site

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,9 @@ protected resource once the authentication workflow is completed).
 require `session` in order to support post-authentication redirection to
 previously-unauthorized resources, retention of tokens and nonces for
 workflows like OpenId and oAuth, etc.  HTTP Basic is the only provided
-workflow that does not require `session` middleware.)
+workflow that does not require `session` middleware. In [the demos](http://friend-demo.herokuapp.com),
+all of the necessary middleware is provided by the `compojure.handler/site` 
+composite function.)
 
 ### Workflows
 


### PR DESCRIPTION
Being fairly new to compojure and friend, I was a little confused at first as to what was actually providing the cookie/session functionality in the demos. It took a couple scans of code before I discovered compojure.handler/site, which I wasn't familiar with. Adding this line to the docs might make it a little clearer exactly how friend is dependent on the session and param middleware.
