### PR TITLE
Don't allow empty role set to be passed to wrap-authorize

### DIFF
--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -364,6 +364,9 @@ which contains a map to be called with a ring handler."
    ordering of your routes, or on 404 requests.  Using something like Compojure's
    `context` makes such arrangements easy to maintain."
   [handler roles]
+  (if (empty? roles)
+    (throw (IllegalArgumentException. "roles cannot be empty")))
+
   (fn [request]
     (if (authorized? roles (identity request))
       (handler request)

--- a/test/test_friend/middleware.clj
+++ b/test/test_friend/middleware.clj
@@ -1,0 +1,12 @@
+(ns test-friend.middleware
+  (:use clojure.test
+        [compojure.core :only (defroutes GET)])
+  (:require [cemerick.friend :refer [wrap-authorize]]))
+
+(defroutes ^{:private true} routes
+  (GET "/path" request "Response"))
+
+(deftest wrap-authorize-throws-on-empty-role-set
+  (testing "wrap-authorize throws IllegalArgumentException on empty roles set"
+    (is (thrown? IllegalArgumentException (wrap-authorize routes #{})))))
+


### PR DESCRIPTION
I've added the check in wrap-authorize and written a single unit test to verify it's being thrown.

It might be necessary to add the check in the authorized? function instead. This would cover the case where an empty roles set is passed to the authorize macro, which could have the same effect as passing an empty role set to wrap-authorize.

For now, this would have to suffice.
