### PR TITLE
Fix Google federated login auth, and reduce ConsumerManager instantiations

### DIFF
--- a/src/cemerick/friend/openid.clj
+++ b/src/cemerick/friend/openid.clj
@@ -55,6 +55,7 @@
                     (.authenticate mgr provider-info return-url)))
         discovery-key (str (java.util.UUID/randomUUID))]
     (swap! discovery-cache assoc discovery-key provider-info)
+    (.setHandle auth-req "")
     (assoc (ring.util.response/redirect (.getDestinationUrl auth-req true))
       :session (assoc session ::openid-disc discovery-key))))
 
@@ -102,14 +103,14 @@
            user-identifier-param "identifier"
            max-nonce-age 60000}
       :as openid-config}]
-  (let [mgr (or consumer-manager
-                (doto (ConsumerManager.)
-                  (.setAssociations (InMemoryConsumerAssociationStore.))
-                  (.setNonceVerifier (InMemoryNonceVerifier. (/ max-nonce-age 1000)))))
-        discovery-cache (atom (cache/ttl-cache-factory {} :ttl max-nonce-age))]
     (fn [{:keys [ request-method params] :as request}]
       (when (=  (req/path-info request) openid-uri)
-        (let [params (clojure.walk/stringify-keys params)
+        (let [mgr (or consumer-manager
+                      (doto (ConsumerManager.)
+                        (.setAssociations (InMemoryConsumerAssociationStore.))
+                        (.setNonceVerifier (InMemoryNonceVerifier. (/ max-nonce-age 1000)))))
+              discovery-cache (atom (cache/ttl-cache-factory {} :ttl max-nonce-age))
+              params (clojure.walk/stringify-keys params)
               user-identifier (and (= request-method :post)
                                    (get params (name user-identifier-param)))]
           (cond
@@ -128,4 +129,4 @@
 
             ;; TODO correct response code?
             :else ((gets :login-failure-handler openid-config (::friend/auth-config request))
-                    request)))))))
+                    request))))))


### PR DESCRIPTION
I ran into this problem: http://blog.a25apps.com/2013/04/19/fix-for-google-federated-login-api/ and fixed that (line 58). In addition, for some reason I'm getting huge loads of 

```
mei 23, 2014 2:43:45 PM org.openid4java.server.RealmVerifier setEnforceRpId
WARNING: RP discovery / realm validation disabled;
```

entries in my log when using the openid workflow. One for every HTTP request (to any URL). I figured out this is because the `ConsumerManager` and things are instantiated _outside_ the check for the `openid-url`. I now moved it inside of the check, which should reduce log load as well as the number of unnecessary objects being created.