### PR TITLE
Cleanup dependency tree

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,6 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [ring/ring-core "1.2.0"]
                  [slingshot "0.10.2"]
-                 [org.clojure/core.incubator "0.1.1"]
 
                  [org.mindrot/jbcrypt "0.3m"]
 

--- a/src/cemerick/friend.clj
+++ b/src/cemerick/friend.clj
@@ -2,8 +2,7 @@
   (:require [cemerick.friend.util :as util]
             [clojure.set :as set])
   (:use (ring.util [response :as response :only (redirect)])
-        [slingshot.slingshot :only (throw+ try+)]
-        [clojure.core.incubator :only (-?>)])
+        [slingshot.slingshot :only (throw+ try+)])
   (:refer-clojure :exclude (identity)))
 
 (def ^{:dynamic true} *default-scheme-ports* {:http 80 :https 443})

--- a/src/cemerick/friend/openid.clj
+++ b/src/cemerick/friend/openid.clj
@@ -6,8 +6,7 @@
             ring.util.response
             [ring.util.request :as req]
             [clojure.core.cache :as cache])
-  (:use clojure.core.incubator
-        [cemerick.friend.util :only (gets)])
+  (:use [cemerick.friend.util :only (gets)])
   (:import (org.openid4java.consumer ConsumerManager VerificationResult
                            InMemoryConsumerAssociationStore
                            InMemoryNonceVerifier)
@@ -79,7 +78,7 @@
 
 (defn- build-credentials
   [^VerificationResult verification]
-  (when-let [identification (-?> verification .getVerifiedId .getIdentifier)]
+  (when-let [identification (some-> verification .getVerifiedId .getIdentifier)]
     (let [response (.getAuthResponse verification)]
       (reduce merge (cons {:identity identification} (gather-attr-maps response))))))
 

--- a/src/cemerick/friend/util.clj
+++ b/src/cemerick/friend/util.clj
@@ -1,10 +1,9 @@
-(ns cemerick.friend.util
-  (:use [clojure.core.incubator :only (-?>>)]))
+(ns cemerick.friend.util)
 
 (defn gets
   "Returns the first value mapped to key found in the provided maps."
   [key & maps]
-  (-?>> (map #(find % key) maps)
+  (some->> (map #(find % key) maps)
         (remove nil?)
         first
         val))

--- a/test/test_friend/mock_app.clj
+++ b/test/test_friend/mock_app.clj
@@ -9,8 +9,7 @@
             [ring.util.response :as resp]
             (compojure [handler :as handler]
                        [route :as route]))
-  (:use [compojure.core :as compojure :only (GET POST ANY defroutes)]
-        [clojure.core.incubator :only (-?>)]))
+  (:use [compojure.core :as compojure :only (GET POST ANY defroutes)]))
 
 
 (def page-bodies {"/login" "Login page here."
@@ -85,7 +84,7 @@
                                  (reset! missles-fired? "shouldn't happen")))
   
   (GET "/view-openid" request
-       (str "OpenId authentication? " (-?> request friend/identity friend/current-authentication pr-str)))
+       (str "OpenId authentication? " (some-> request friend/identity friend/current-authentication pr-str)))
   
   ;; FIN
   (route/not-found "404"))


### PR DESCRIPTION
Replaced `core.incubator` usages with core equivalent. This change introduces a dependency an clojure 1.5. Not sure if this is fine (this explains failing tests).
