### PR TITLE
Prevent NPE and StringIndexOutOfBoundException

### DIFF
--- a/src/cemerick/friend/credentials.clj
+++ b/src/cemerick/friend/credentials.clj
@@ -43,6 +43,9 @@ the result of previously hashing that password."
    entry."
   [load-credentials-fn {:keys [username password]}]
   (when-let [creds (load-credentials-fn username)]
-    (let [password-key (or (-> creds meta ::password-key) :password)]
-      (when (bcrypt-verify password (get creds password-key))
+    (let [password-key (or (-> creds meta ::password-key) :password)
+          stored-password (get creds password-key)]
+      (when (and
+             (not (empty? stored-password))
+             (bcrypt-verify password stored-password))
         (dissoc creds password-key)))))

--- a/test/test_friend/credentials.clj
+++ b/test/test_friend/credentials.clj
@@ -8,12 +8,30 @@
            {"username" {:username "joe" :password (creds/hash-bcrypt "foo")}}
            {:username "username" :password "foo"}))))
 
+(deftest empty-password
+  (is (= nil
+         (creds/bcrypt-credential-fn
+          {"username" {:username "joe" :password ""}}
+          {:username "username" :password "foo"}))))
+
+(deftest empty-user-data
+  (is (= nil
+         (creds/bcrypt-credential-fn
+          {"username" {}}
+          {:username "username" :password "foo"}))))
+
+(deftest nil-user-data
+  (is (= nil
+         (creds/bcrypt-credential-fn
+          {"username" nil}
+          {:username "username" :password "foo"}))))
+
 (deftest custom-password-key
-  (is (thrown? NullPointerException
+  (is (= nil
               (creds/bcrypt-credential-fn
                 {"username" {"username" "joe" ::password (creds/hash-bcrypt "foo")}}
                 {:username "username" :password "foo"})))
-  
+
   (is (= {:username "joe"}
          (creds/bcrypt-credential-fn
            {"username" ^{::creds/password-key ::password}


### PR DESCRIPTION
When credentials load function return empty user data map (eg. when user
does not exist) NPE was thrown by bcrypt-credential-fn.

Also when :password with empty string was returned the
StringIndexOutOfBoundException was thrown

This patch fixes both exceptions making usage of friend easier and more
intuitive.